### PR TITLE
Properly escape custom props

### DIFF
--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -2,7 +2,6 @@ import { mock } from 'jest-mock-extended'
 import { PluginAPI } from 'tailwindcss/types/config'
 import multiThemePlugin from '.'
 import { Theme } from './config'
-import { escape } from './utils/customPropUtils'
 import { MultiThemePluginOptions, defaultThemeName } from './utils/optionsUtils'
 
 describe('multiThemePlugin', () => {
@@ -25,6 +24,9 @@ describe('multiThemePlugin', () => {
               colors: {
                 primary: 'another',
                 secondary: 'something'
+              },
+              spacing: {
+                '0.5': '10px'
               }
             }
           }
@@ -58,14 +60,15 @@ describe('multiThemePlugin', () => {
 
       expect(api.addBase).toHaveBeenCalledWith({
         ':root': {
-          [escape('--colors-primary')]: 'thing'
+          ['--colors-primary']: 'thing'
         }
       })
       for (const theme of config.themes ?? []) {
         expect(api.addBase).toHaveBeenCalledWith({
           [`.escaped-${theme.name}`]: {
             ['--colors-primary']: 'another',
-            ['--colors-secondary']: 'something'
+            ['--colors-secondary']: 'something',
+            ['--spacing-0\\.5']: '10px'
           }
         })
       }

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -64,8 +64,8 @@ describe('multiThemePlugin', () => {
       for (const theme of config.themes ?? []) {
         expect(api.addBase).toHaveBeenCalledWith({
           [`.escaped-${theme.name}`]: {
-            [escape('--colors-primary')]: 'another',
-            [escape('--colors-secondary')]: 'something'
+            ['--colors-primary']: 'another',
+            ['--colors-secondary']: 'something'
           }
         })
       }

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -60,15 +60,15 @@ describe('multiThemePlugin', () => {
 
       expect(api.addBase).toHaveBeenCalledWith({
         ':root': {
-          ['--colors-primary']: 'thing'
+          '--colors-primary': 'thing'
         }
       })
       for (const theme of config.themes ?? []) {
         expect(api.addBase).toHaveBeenCalledWith({
           [`.escaped-${theme.name}`]: {
-            ['--colors-primary']: 'another',
-            ['--colors-secondary']: 'something',
-            ['--spacing-0\\.5']: '10px'
+            '--colors-primary': 'another',
+            '--colors-secondary': 'something',
+            '--spacing-0\\.5': '10px'
           }
         })
       }

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,9 +1,9 @@
-import { Theme } from './config'
-import multiThemePlugin from '.'
-import { MultiThemePluginOptions } from './utils/optionsUtils'
-import { defaultThemeName } from './utils/optionsUtils'
-import { PluginAPI } from 'tailwindcss/types/config'
 import { mock } from 'jest-mock-extended'
+import { PluginAPI } from 'tailwindcss/types/config'
+import multiThemePlugin from '.'
+import { Theme } from './config'
+import { escape } from './utils/customPropUtils'
+import { MultiThemePluginOptions, defaultThemeName } from './utils/optionsUtils'
 
 describe('multiThemePlugin', () => {
   describe('handler', () => {
@@ -58,14 +58,14 @@ describe('multiThemePlugin', () => {
 
       expect(api.addBase).toHaveBeenCalledWith({
         ':root': {
-          '--colors-primary': 'thing'
+          [escape('--colors-primary')]: 'thing'
         }
       })
       for (const theme of config.themes ?? []) {
         expect(api.addBase).toHaveBeenCalledWith({
           [`.escaped-${theme.name}`]: {
-            '--colors-primary': 'another',
-            '--colors-secondary': 'something'
+            [escape('--colors-primary')]: 'another',
+            [escape('--colors-secondary')]: 'something'
           }
         })
       }

--- a/src/utils/customPropUtils.ts
+++ b/src/utils/customPropUtils.ts
@@ -1,6 +1,18 @@
 import { isColor, toRgb, withOpacity } from './colorUtils'
 
 /**
+ * Code copied from the tailwind official codebase
+ * @link https://github.com/tailwindlabs/tailwindcss/blob/fbbba6f67f73c3a4f9571649c3fc27006446d8f4/src/lib/regex.js#L70
+ */
+const REGEX_SPECIAL = /[\\^$.*+?()[\]{}|]/g
+const REGEX_HAS_SPECIAL = RegExp(REGEX_SPECIAL.source)
+export const escape = (string?: string): string => {
+  return string && REGEX_HAS_SPECIAL.test(string)
+    ? string.replace(REGEX_SPECIAL, '\\$&')
+    : string || ''
+}
+
+/**
  * @param value - a custom prop value
  * @return the value converted to a string of its rgb components comma separated if it is a color else it returns the value unaltered
  */
@@ -27,9 +39,9 @@ export const toCustomPropName = (valuePath: string[]): string => {
       )}"`
     )
   }
-  return `--${valuePath
-    .filter(step => step.toLowerCase() !== 'default')
-    .join('-')}`
+  return escape(
+    `--${valuePath.filter(step => step.toLowerCase() !== 'default').join('-')}`
+  )
 }
 
 /**

--- a/src/utils/themeUtils.spec.ts
+++ b/src/utils/themeUtils.spec.ts
@@ -702,7 +702,7 @@ describe('themeUtils', () => {
           helpers
         )
       ).toEqual({
-        [escape('--foo')]: 'thing'
+        ['--foo']: 'thing'
       })
     })
 

--- a/src/utils/themeUtils.spec.ts
+++ b/src/utils/themeUtils.spec.ts
@@ -1,10 +1,11 @@
+import { mock } from 'jest-mock-extended'
+import { PluginAPI } from 'tailwindcss/types/config'
+import { PluginUtils, TailwindExtension, Theme } from '../config'
+import { escape } from './customPropUtils'
 import {
   resolveThemeExtensionAsCustomProps,
   resolveThemeExtensionsAsTailwindExtension
 } from './themeUtils'
-import { PluginUtils, TailwindExtension, Theme } from '../config'
-import { PluginAPI } from 'tailwindcss/types/config'
-import { mock } from 'jest-mock-extended'
 
 describe('themeUtils', () => {
   let pluginUtils: PluginUtils
@@ -701,7 +702,7 @@ describe('themeUtils', () => {
           helpers
         )
       ).toEqual({
-        '--foo': 'thing'
+        [escape('--foo')]: 'thing'
       })
     })
 
@@ -721,8 +722,8 @@ describe('themeUtils', () => {
           helpers
         )
       ).toEqual({
-        '--colors-primary': 'thing',
-        '--foo-bar-bazz': 'value'
+        [escape('--colors-primary')]: 'thing',
+        [escape('--foo-bar-bazz')]: 'value'
       })
     })
 
@@ -744,8 +745,8 @@ describe('themeUtils', () => {
           helpers
         )
       ).toEqual({
-        '--foo-bar-0-thing': '1',
-        '--foo-bar-1-thing': '2'
+        [escape('--foo-bar-0-thing')]: '1',
+        [escape('--foo-bar-1-thing')]: '2'
       })
     })
 
@@ -760,9 +761,9 @@ describe('themeUtils', () => {
           helpers
         )
       ).toEqual({
-        '--fontFamily-serif-0': 'Times New Roman',
-        '--fontFamily-serif-1': 'Times',
-        '--fontFamily-serif-2': 'serif'
+        [escape('--fontFamily-serif-0')]: 'Times New Roman',
+        [escape('--fontFamily-serif-1')]: 'Times',
+        [escape('--fontFamily-serif-2')]: 'serif'
       })
     })
 
@@ -777,7 +778,7 @@ describe('themeUtils', () => {
           helpers
         )
       ).toEqual({
-        '--colors-primary': '17, 70, 17'
+        [escape('--colors-primary')]: '17, 70, 17'
       })
     })
 
@@ -802,9 +803,9 @@ describe('themeUtils', () => {
           helpers
         )
       ).toEqual({
-        '--colors-red': 'thing',
-        '--foo': 'thing',
-        '--myArray-0': '1'
+        [escape('--colors-red')]: 'thing',
+        [escape('--foo')]: 'thing',
+        [escape('--myArray-0')]: '1'
       })
     })
 
@@ -856,7 +857,7 @@ describe('themeUtils', () => {
             helpers
           )
         ).toEqual({
-          '--colors-primary': 'some.key'
+          [escape('--colors-primary')]: 'some.key'
         })
       })
 

--- a/src/utils/themeUtils.spec.ts
+++ b/src/utils/themeUtils.spec.ts
@@ -701,7 +701,7 @@ describe('themeUtils', () => {
           helpers
         )
       ).toEqual({
-        ['--foo']: 'thing'
+        '--foo': 'thing'
       })
     })
 
@@ -721,8 +721,8 @@ describe('themeUtils', () => {
           helpers
         )
       ).toEqual({
-        ['--colors-primary']: 'thing',
-        ['--foo-bar-bazz']: 'value'
+        '--colors-primary': 'thing',
+        '--foo-bar-bazz': 'value'
       })
     })
 
@@ -744,8 +744,8 @@ describe('themeUtils', () => {
           helpers
         )
       ).toEqual({
-        ['--foo-bar-0-thing']: '1',
-        ['--foo-bar-1-thing']: '2'
+        '--foo-bar-0-thing': '1',
+        '--foo-bar-1-thing': '2'
       })
     })
 
@@ -760,9 +760,9 @@ describe('themeUtils', () => {
           helpers
         )
       ).toEqual({
-        ['--fontFamily-serif-0']: 'Times New Roman',
-        ['--fontFamily-serif-1']: 'Times',
-        ['--fontFamily-serif-2']: 'serif'
+        '--fontFamily-serif-0': 'Times New Roman',
+        '--fontFamily-serif-1': 'Times',
+        '--fontFamily-serif-2': 'serif'
       })
     })
 
@@ -777,7 +777,7 @@ describe('themeUtils', () => {
           helpers
         )
       ).toEqual({
-        ['--colors-primary']: '17, 70, 17'
+        '--colors-primary': '17, 70, 17'
       })
     })
 
@@ -802,9 +802,9 @@ describe('themeUtils', () => {
           helpers
         )
       ).toEqual({
-        ['--colors-red']: 'thing',
-        ['--foo']: 'thing',
-        ['--myArray-0']: '1'
+        '--colors-red': 'thing',
+        '--foo': 'thing',
+        '--myArray-0': '1'
       })
     })
 
@@ -856,7 +856,7 @@ describe('themeUtils', () => {
             helpers
           )
         ).toEqual({
-          ['--colors-primary']: 'some.key'
+          '--colors-primary': 'some.key'
         })
       })
 

--- a/src/utils/themeUtils.spec.ts
+++ b/src/utils/themeUtils.spec.ts
@@ -1,7 +1,6 @@
 import { mock } from 'jest-mock-extended'
 import { PluginAPI } from 'tailwindcss/types/config'
 import { PluginUtils, TailwindExtension, Theme } from '../config'
-import { escape } from './customPropUtils'
 import {
   resolveThemeExtensionAsCustomProps,
   resolveThemeExtensionsAsTailwindExtension
@@ -722,8 +721,8 @@ describe('themeUtils', () => {
           helpers
         )
       ).toEqual({
-        [escape('--colors-primary')]: 'thing',
-        [escape('--foo-bar-bazz')]: 'value'
+        ['--colors-primary']: 'thing',
+        ['--foo-bar-bazz']: 'value'
       })
     })
 
@@ -745,8 +744,8 @@ describe('themeUtils', () => {
           helpers
         )
       ).toEqual({
-        [escape('--foo-bar-0-thing')]: '1',
-        [escape('--foo-bar-1-thing')]: '2'
+        ['--foo-bar-0-thing']: '1',
+        ['--foo-bar-1-thing']: '2'
       })
     })
 
@@ -761,9 +760,9 @@ describe('themeUtils', () => {
           helpers
         )
       ).toEqual({
-        [escape('--fontFamily-serif-0')]: 'Times New Roman',
-        [escape('--fontFamily-serif-1')]: 'Times',
-        [escape('--fontFamily-serif-2')]: 'serif'
+        ['--fontFamily-serif-0']: 'Times New Roman',
+        ['--fontFamily-serif-1']: 'Times',
+        ['--fontFamily-serif-2']: 'serif'
       })
     })
 
@@ -778,7 +777,7 @@ describe('themeUtils', () => {
           helpers
         )
       ).toEqual({
-        [escape('--colors-primary')]: '17, 70, 17'
+        ['--colors-primary']: '17, 70, 17'
       })
     })
 
@@ -803,9 +802,9 @@ describe('themeUtils', () => {
           helpers
         )
       ).toEqual({
-        [escape('--colors-red')]: 'thing',
-        [escape('--foo')]: 'thing',
-        [escape('--myArray-0')]: '1'
+        ['--colors-red']: 'thing',
+        ['--foo']: 'thing',
+        ['--myArray-0']: '1'
       })
     })
 
@@ -857,7 +856,7 @@ describe('themeUtils', () => {
             helpers
           )
         ).toEqual({
-          [escape('--colors-primary')]: 'some.key'
+          ['--colors-primary']: 'some.key'
         })
       })
 


### PR DESCRIPTION
fixes #64 

I've tried taking advantage of the `api.e` function, but I've then discovered that it cannot be passed [here](https://github.com/RyanClementsHax/tailwindcss-themer/blob/b1a921575c55366f1d6de6bc1af36476fbbb03f3/src/index.ts#L61)

Probably tailwindcss package should expose the escape function directly or give the possibility to pass the api object to create the theme config 🤔 